### PR TITLE
[FEAT] 게시물 전체조회 기능 구현

### DIFF
--- a/jointSeminar/build.gradle
+++ b/jointSeminar/build.gradle
@@ -22,6 +22,7 @@ repositories {
 }
 
 dependencies {
+	runtimeOnly 'com.h2database:h2'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/common/response/ApiResponse.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/common/response/ApiResponse.java
@@ -1,0 +1,20 @@
+package com.sopt.jointSeminar.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+
+    private final boolean success;
+    private final int code;
+    private final String status;
+    private T data;
+
+    public static <T> ApiResponse<T> success(SuccessStatus success, T data) {
+        return new ApiResponse<T>(true, success.getStatusCode(), success.getMessage(), data);
+    }
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/common/response/SuccessStatus.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/common/response/SuccessStatus.java
@@ -1,0 +1,20 @@
+package com.sopt.jointSeminar.common.response;
+
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+public enum SuccessStatus {
+    POST_GET_OK(HttpStatus.OK,"게시물 조회 성공");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    public int getStatusCode() {
+        return this.httpStatus.value();
+    }
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/controller/PostController.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/controller/PostController.java
@@ -1,0 +1,26 @@
+package com.sopt.jointSeminar.controller;
+
+import com.sopt.jointSeminar.common.response.ApiResponse;
+import com.sopt.jointSeminar.common.response.SuccessStatus;
+import com.sopt.jointSeminar.dto.response.PostGetResponse;
+import com.sopt.jointSeminar.service.PostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @GetMapping
+    public ApiResponse<List<PostGetResponse>> getPosts() {
+        return ApiResponse.success(SuccessStatus.POST_GET_OK, postService.getPosts());
+    }
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/controller/controller.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/controller/controller.java
@@ -1,4 +1,0 @@
-package com.sopt.jointSeminar.controller;
-
-public class controller {
-}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/domain/Post.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/domain/Post.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "post")
-public class Post extends BaseTimeEntity {
+public class Post {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long postId;

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/domain/Post.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/domain/Post.java
@@ -1,0 +1,25 @@
+package com.sopt.jointSeminar.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "post")
+public class Post extends BaseTimeEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long postId;
+
+    private String title;
+    private String date;
+
+    @Builder
+    public Post(String title) {
+        this.title = title;
+    }
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/domain/domain.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/domain/domain.java
@@ -1,4 +1,0 @@
-package com.sopt.jointSeminar.domain;
-
-public class domain {
-}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/dto/dto.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/dto/dto.java
@@ -1,4 +1,0 @@
-package com.sopt.jointSeminar.dto;
-
-public class dto {
-}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/dto/response/PostGetResponse.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/dto/response/PostGetResponse.java
@@ -1,0 +1,19 @@
+package com.sopt.jointSeminar.dto.response;
+
+import com.sopt.jointSeminar.domain.Post;
+
+import java.time.LocalDateTime;
+
+public record PostGetResponse(
+    Long id,
+    String title,
+    String date
+) {
+    public static PostGetResponse of(Post post) {
+        return new PostGetResponse(
+                post.getPostId(),
+                post.getTitle(),
+                post.getDate()
+        );
+    }
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/repository/PostJpaRepository.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/repository/PostJpaRepository.java
@@ -1,0 +1,9 @@
+package com.sopt.jointSeminar.repository;
+
+import com.sopt.jointSeminar.domain.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostJpaRepository extends JpaRepository<Post, Long> {
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/repository/repository.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/repository/repository.java
@@ -1,4 +1,0 @@
-package com.sopt.jointSeminar.repository;
-
-public class repository {
-}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/service/PostService.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/service/PostService.java
@@ -1,0 +1,24 @@
+package com.sopt.jointSeminar.service;
+
+import com.sopt.jointSeminar.dto.response.PostGetResponse;
+import com.sopt.jointSeminar.repository.PostJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PostService {
+
+    private final PostJpaRepository postJpaRepository;
+
+    public List<PostGetResponse> getPosts() {
+        return postJpaRepository.findAll()
+                .stream()
+                .map(post -> PostGetResponse.of(post))
+                .toList();
+    }
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/service/service.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/service/service.java
@@ -1,4 +1,0 @@
-package com.sopt.jointSeminar.service;
-
-public class service {
-}


### PR DESCRIPTION
##  작업한 내용
- Post 도메인 추가
- PostGetResponse DTO 추가
- PostService 서비스 추가
- PostJpaRepository 레포지토리 추가
- PostController 컨트롤러 추가
- 공통으로 사용할 ApiResponse, SuccessStatus 파일 추가
- 기존 필요없는 파일(dto, service, controller 등) 삭제

##  PR Point
- 공통으로 사용할 ApiResponse, SuccessStatus 파일 부분 코드 봐주시구 수정할 부분 알려주세용!
- 게시물에 날짜는 string 형식으로 했습니다

## 관련 이슈
- Resolved: #2 

## 결과

<img width="500" alt="스크린샷 2023-11-21 21 01 22" src="https://github.com/SOPT-33th-JointSeminar-3/Server/assets/76610340/9ec48164-772e-43da-b8e6-00126235dea7">
