### PR TITLE
[FEAT] 국가 검색 조회 기능 구현 

### DIFF
--- a/jointSeminar/.gitignore
+++ b/jointSeminar/.gitignore
@@ -38,3 +38,4 @@ out/
 
 *.yml
 **/application.properties
+*.sql

--- a/jointSeminar/build.gradle
+++ b/jointSeminar/build.gradle
@@ -28,6 +28,13 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	//database
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('bootBuildImage') {

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/common/dto/ApiResponse.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/common/dto/ApiResponse.java
@@ -1,0 +1,45 @@
+package com.sopt.jointSeminar.common.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.sopt.jointSeminar.common.exception.Success;
+import com.sopt.jointSeminar.common.exception.Error;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+// 직렬화 할 때 property 순서 지정
+@JsonPropertyOrder({"code", "status", "data"})
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ApiResponse<T> {
+
+    private final int code;
+    private final String mgs;
+
+//    null인 데이터는 제외
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+
+//    데이터가 없는 응답 성공
+    public static ApiResponse<?> success(Success success) {
+        return new ApiResponse<>(success.getHttpStatusCode(), success.getMsg());
+    }
+
+//    데이터가 있는 응답 성공
+    public static <T> ApiResponse<T> success(Success success, T data) {
+        return new ApiResponse<T>(success.getHttpStatusCode(), success.getMsg(), data);
+    }
+
+    public static ApiResponse<?> error(Error error) {
+        return new ApiResponse<>(error.getHttpStatusCode(), error.getMsg());
+    }
+
+    public <T> ApiResponse<T> error(Error error, T data) {
+        return new ApiResponse<T>(error.getHttpStatusCode(), error.getMsg(), data);
+    }
+
+}
+

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/common/exception/Error.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/common/exception/Error.java
@@ -1,0 +1,20 @@
+package com.sopt.jointSeminar.common.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Error {
+    NOT_FOUND_NATION_ERROR(HttpStatus.NOT_FOUND, "존재하지 않는 국가"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 서버 에러");
+
+    private final HttpStatus httpStatus;
+    private final String Msg;
+
+    public int getHttpStatusCode() {
+        return httpStatus.value();
+    }
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/common/exception/Success.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/common/exception/Success.java
@@ -1,0 +1,27 @@
+package com.sopt.jointSeminar.common.exception;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum Success {
+
+    PROCESS_SUCCESS(HttpStatus.OK, "OK"),
+    GET_SEARCH_SECCESS(HttpStatus.OK, "국가 조회 성공");
+
+
+
+
+    private final HttpStatus httpStatus;
+    private final String msg;
+
+
+//    현재 상태 코드 반환
+    public int getHttpStatusCode() {
+        return httpStatus.value();
+    }
+
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/config/CorsConfig.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/config/CorsConfig.java
@@ -25,5 +25,4 @@ public class CorsConfig {
         source.registerCorsConfiguration("/**", config);
         return source;
     }
-
 }

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/config/CorsConfig.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/config/CorsConfig.java
@@ -1,0 +1,29 @@
+package com.sopt.jointSeminar.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowCredentials(true);
+        config.setAllowedOrigins(List.of("http://localhost:3000"));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setExposedHeaders(List.of("*"));
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/config/SecurityConfig.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/config/SecurityConfig.java
@@ -1,0 +1,25 @@
+package com.sopt.jointSeminar.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.httpBasic().disable();
+        http.csrf().disable(); // 외부 POST 요청을 받아야하니 csrf는 꺼준다.
+        http.cors(); // ⭐ CORS를 커스텀하려면 이렇게
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+
+        http.authorizeHttpRequests()
+                .requestMatchers("/**").permitAll()
+                .anyRequest().authenticated();
+
+        return http.build();
+    }
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/controller/NationController.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/controller/NationController.java
@@ -24,6 +24,4 @@ public class NationController {
     public ApiResponse<List<NationSearchResponse>> searchNation(@RequestParam String words) {
         return ApiResponse.success(Success.GET_SEARCH_SECCESS, nationService.searchNation(words));
     }
-
-
 }

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/controller/NationController.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/controller/NationController.java
@@ -1,0 +1,34 @@
+package com.sopt.jointSeminar.controller;
+
+import com.sopt.jointSeminar.common.dto.ApiResponse;
+import com.sopt.jointSeminar.common.exception.Success;
+import com.sopt.jointSeminar.dto.response.NationSearchResponse;
+import com.sopt.jointSeminar.service.NationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/nation")
+@RequiredArgsConstructor
+public class NationController {
+
+    private final NationService nationService;
+
+    @GetMapping("/searchv1")
+    public ResponseEntity<List<NationSearchResponse>> searchNationv1(@RequestParam String nation) {
+        return ResponseEntity.ok(nationService.searchNation(nation));
+    }
+
+    @GetMapping("/search")
+    public ApiResponse<List<NationSearchResponse>> searchNation(@RequestParam String nation) {
+        return ApiResponse.success(Success.GET_SEARCH_SECCESS, nationService.searchNation(nation));
+    }
+
+
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/controller/NationController.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/controller/NationController.java
@@ -20,14 +20,9 @@ public class NationController {
 
     private final NationService nationService;
 
-    @GetMapping("/searchv1")
-    public ResponseEntity<List<NationSearchResponse>> searchNationv1(@RequestParam String nation) {
-        return ResponseEntity.ok(nationService.searchNation(nation));
-    }
-
     @GetMapping("/search")
-    public ApiResponse<List<NationSearchResponse>> searchNation(@RequestParam String nation) {
-        return ApiResponse.success(Success.GET_SEARCH_SECCESS, nationService.searchNation(nation));
+    public ApiResponse<List<NationSearchResponse>> searchNation(@RequestParam String words) {
+        return ApiResponse.success(Success.GET_SEARCH_SECCESS, nationService.searchNation(words));
     }
 
 

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/controller/controller.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/controller/controller.java
@@ -1,4 +1,0 @@
-package com.sopt.jointSeminar.controller;
-
-public class controller {
-}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/domain/Nation.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/domain/Nation.java
@@ -1,0 +1,33 @@
+package com.sopt.jointSeminar.domain;
+
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Nation {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long nationId;
+
+    private String nationName;
+    private String itatCode;
+    private String city;
+    
+//    일대다(항공편) 출발국가
+
+
+    @Builder
+    public Nation(String nationName, String itatCode, String city) {
+        this.nationName = nationName;
+        this.itatCode = itatCode;
+        this.city = city;
+    }
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/domain/Nation.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/domain/Nation.java
@@ -20,9 +20,6 @@ public class Nation {
     private String nationName;
     private String itatCode;
     private String city;
-    
-//    일대다(항공편) 출발국가
-
 
     @Builder
     public Nation(String nationName, String itatCode, String city) {

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/domain/domain.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/domain/domain.java
@@ -1,4 +1,0 @@
-package com.sopt.jointSeminar.domain;
-
-public class domain {
-}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/dto/dto.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/dto/dto.java
@@ -1,4 +1,0 @@
-package com.sopt.jointSeminar.dto;
-
-public class dto {
-}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/dto/response/NationSearchResponse.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/dto/response/NationSearchResponse.java
@@ -1,0 +1,21 @@
+package com.sopt.jointSeminar.dto.response;
+
+import com.sopt.jointSeminar.domain.Nation;
+
+public record NationSearchResponse(
+        Long nationId,
+        String nationName,
+        String itatCode,
+        String city) {
+
+    public static NationSearchResponse of(Nation nation) {
+        return new NationSearchResponse(
+                nation.getNationId(),
+                nation.getNationName(),
+                nation.getItatCode(),
+                nation.getCity()
+        );
+    }
+
+}
+

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/dto/response/NationSearchResponse.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/dto/response/NationSearchResponse.java
@@ -16,6 +16,5 @@ public record NationSearchResponse(
                 nation.getCity()
         );
     }
-
 }
 

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/repository/NationJpaRepository.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/repository/NationJpaRepository.java
@@ -1,0 +1,13 @@
+package com.sopt.jointSeminar.repository;
+
+import com.sopt.jointSeminar.domain.Nation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+//import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+
+public interface NationJpaRepository extends JpaRepository<Nation, Long> {
+
+    List<Nation> findByNationNameContainingOrItatCodeContainingOrCityContaining(String nationName, String itatCode, String city);
+
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/repository/NationJpaRepository.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/repository/NationJpaRepository.java
@@ -2,11 +2,7 @@ package com.sopt.jointSeminar.repository;
 
 import com.sopt.jointSeminar.domain.Nation;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-
 import java.util.List;
-//import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface NationJpaRepository extends JpaRepository<Nation, Long> {
 

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/repository/NationJpaRepository.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/repository/NationJpaRepository.java
@@ -2,12 +2,14 @@ package com.sopt.jointSeminar.repository;
 
 import com.sopt.jointSeminar.domain.Nation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 //import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
 public interface NationJpaRepository extends JpaRepository<Nation, Long> {
 
-    List<Nation> findByNationNameContainingOrItatCodeContainingOrCityContaining(String nationName, String itatCode, String city);
+    List<Nation> findByNationNameContainingIgnoreCaseOrItatCodeContainingIgnoreCaseOrCityContainingIgnoreCase(String nationName, String itatCode, String city);
 
 }

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/repository/repository.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/repository/repository.java
@@ -1,4 +1,0 @@
-package com.sopt.jointSeminar.repository;
-
-public class repository {
-}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/service/NationService.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/service/NationService.java
@@ -1,0 +1,31 @@
+package com.sopt.jointSeminar.service;
+
+
+import com.sopt.jointSeminar.domain.Nation;
+import com.sopt.jointSeminar.dto.response.NationSearchResponse;
+import com.sopt.jointSeminar.repository.NationJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NationService {
+    private final NationJpaRepository nationJpaRepository;
+
+    public List<NationSearchResponse> searchNation(String words) {
+
+        return nationJpaRepository.findByNationNameContainingOrItatCodeContainingOrCityContaining(words, words, words)
+                .stream()
+                .map(NationSearchResponse::of)
+//                .map(nation -> NationSearchResponse.of(nation))
+                .toList();
+    }
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/service/NationService.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/service/NationService.java
@@ -18,11 +18,12 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class NationService {
+
     private final NationJpaRepository nationJpaRepository;
 
     public List<NationSearchResponse> searchNation(String words) {
 
-        return nationJpaRepository.findByNationNameContainingOrItatCodeContainingOrCityContaining(words, words, words)
+        return nationJpaRepository.findByNationNameContainingIgnoreCaseOrItatCodeContainingIgnoreCaseOrCityContainingIgnoreCase(words, words, words)
                 .stream()
                 .map(NationSearchResponse::of)
 //                .map(nation -> NationSearchResponse.of(nation))

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/service/NationService.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/service/NationService.java
@@ -26,7 +26,6 @@ public class NationService {
         return nationJpaRepository.findByNationNameContainingIgnoreCaseOrItatCodeContainingIgnoreCaseOrCityContainingIgnoreCase(words, words, words)
                 .stream()
                 .map(NationSearchResponse::of)
-//                .map(nation -> NationSearchResponse.of(nation))
                 .toList();
     }
 }

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/service/service.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/service/service.java
@@ -1,4 +1,0 @@
-package com.sopt.jointSeminar.service;
-
-public class service {
-}


### PR DESCRIPTION
##  작업한 내용
- Nation 도메인 추가
- NationSearchResponse DTO 추가
- NationService 서비스 추가
- NationJpaRepository 레포지토리 추가
- NationController 컨트롤러 추가
- 공통으로 사용할 ApiResponse, Success, Error 파일 추가 (추후 하나로 합칠 예정)
- 기존 필요없는 파일(dto, service, controller 등) 삭제
- Security Config 추가
- Cors error 해결을 위한 CorsConfig 추가
- gitignore 변경

##  PR Point
- 공통 형식으로 ApiResponse는 추후에 동일하게 변경할 예정이니 우선적으로 나머지 코드부터 확인해주세요!
-  검색은 국가이름, 도시이름, ITAT코드 모두 검색되게 했으며, 대/소문자 상관없이 모두 검색되도록 구현했습니다.

## 관련 이슈
- Resolved: #3 

## 결과
<img width="647" alt="search api1" src="https://github.com/SOPT-33th-JointSeminar-3/Server/assets/102401928/0166735b-55ce-4004-9998-31ba0990198f">

<img width="629" alt="search api2" src="https://github.com/SOPT-33th-JointSeminar-3/Server/assets/102401928/c5e51818-22a7-4a38-a03d-9bc3c4e49662">



