### PR TITLE
[FEAT] 승객 예약 생성 기능 구현

### DIFF
--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/common/exception/SuccessStatus.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/common/exception/SuccessStatus.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum SuccessStatus {
     POST_GET_OK(HttpStatus.OK,"게시물 조회 성공"),
     PROCESS_SUCCESS(HttpStatus.OK, "OK"),
-    GET_SEARCH_SECCESS(HttpStatus.OK, "국가 조회 성공");
+    GET_SEARCH_SECCESS(HttpStatus.OK, "국가 조회 성공"),
+    CREATE_PASSENGER_SUCCESS(HttpStatus.CREATED, "승객 예약 생성 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/controller/PassengerController.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/controller/PassengerController.java
@@ -1,0 +1,26 @@
+package com.sopt.jointSeminar.controller;
+
+import com.sopt.jointSeminar.common.dto.ApiResponse;
+import com.sopt.jointSeminar.common.exception.SuccessStatus;
+import com.sopt.jointSeminar.service.PassengerService;
+import com.sopt.jointSeminar.dto.request.PassengerBookRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/passenger")
+@RequiredArgsConstructor
+public class PassengerController {
+
+    private final PassengerService passengerService;
+
+    @PostMapping
+    public ApiResponse<?> bookPassenger(@RequestBody PassengerBookRequest request) {
+        return ApiResponse.success(SuccessStatus.CREATE_PASSENGER_SUCCESS, passengerService.book(request));
+    }
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/domain/Passenger.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/domain/Passenger.java
@@ -1,0 +1,36 @@
+package com.sopt.jointSeminar.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Passenger {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long passengerId;
+
+    private String firstname;
+    private String lastname;
+    private String gender;
+    private LocalDate birth;
+
+//    Naiton 정보 연결?
+
+    @Builder
+    public Passenger(String firstname, String lastname, String gender, LocalDate birth) {
+        this.firstname = firstname;
+        this.lastname = lastname;
+        this.gender = gender;
+        this.birth = birth;
+    }
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/dto/request/PassengerBookRequest.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/dto/request/PassengerBookRequest.java
@@ -1,0 +1,11 @@
+package com.sopt.jointSeminar.dto.request;
+
+import java.time.LocalDate;
+
+public record PassengerBookRequest(
+        String firstname,
+        String lastname,
+        String gender,
+        LocalDate birth
+) {
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/repository/PassengerRepository.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/repository/PassengerRepository.java
@@ -1,0 +1,8 @@
+package com.sopt.jointSeminar.repository;
+
+import com.sopt.jointSeminar.domain.Passenger;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PassengerRepository extends JpaRepository<Passenger, Long> {
+
+}

--- a/jointSeminar/src/main/java/com/sopt/jointSeminar/service/PassengerService.java
+++ b/jointSeminar/src/main/java/com/sopt/jointSeminar/service/PassengerService.java
@@ -1,0 +1,27 @@
+package com.sopt.jointSeminar.service;
+
+import com.sopt.jointSeminar.domain.Passenger;
+import com.sopt.jointSeminar.dto.request.PassengerBookRequest;
+import com.sopt.jointSeminar.repository.PassengerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PassengerService {
+    private final PassengerRepository passengerRepository;
+
+    @Transactional
+    public String book(PassengerBookRequest request) {
+        Passenger passenger = passengerRepository.save(
+                Passenger.builder()
+                        .firstname(request.firstname())
+                        .lastname(request.lastname())
+                        .gender(request.gender())
+                        .birth(request.birth())
+                        .build()
+        );
+        return passenger.getPassengerId().toString();
+    }
+}


### PR DESCRIPTION
##  작업한 내용
- Passenger 도메인 추가
- PassengerBookRequest DTO 추가
- PassengerService 서비스 추가
- PassengerJpaRepository 레포지토리 추가
- PassengerController 컨트롤러 추가
- PassengerBookRequest 관련 SuccessStatus 추가

##  PR Point
- 항공권에 대한 정보는 없이 Passenger 정보만 받아서 예약 생성하는 기능으로 구현했습니다.
- 추후 ErrorStatus와 예외처리 진행할 예정이니 그 부분은 제외해서 봐주세요!

## 관련 이슈
- Resolved: #7 


## 결과
<img width="529" alt="Passengercreateapi" src="https://github.com/SOPT-33th-JointSeminar-3/Server/assets/102401928/01674a29-cab2-43ea-bf7b-a049eafdf828">

<img width="740" alt="Passengercreatedb저장" src="https://github.com/SOPT-33th-JointSeminar-3/Server/assets/102401928/73a0f3b6-1668-4a06-be8b-39a1fed16259">
